### PR TITLE
Add GitHub Metrics section to profile pages

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -69,7 +69,7 @@ import ProfileCard from "../../components/ProfileCard.astro";
     </section>
 
     <section class="card">
-      <h2 class="main-title">Quick Access</h2>
+      <h2 class="main-title">Links</h2>
       <ul>
         <li>
           <a href="https://github.com/HukuKaich0u" target="_blank" rel="noreferrer" class="external-link">GitHub</a>
@@ -81,6 +81,16 @@ import ProfileCard from "../../components/ProfileCard.astro";
           <a href="https://www.linkedin.com/in/koki-aoyagi-b3b945349/" target="_blank" rel="noreferrer" class="external-link">LinkedIn</a>
         </li>
       </ul>
+    </section>
+
+    <section class="card stack-md">
+      <h2 class="main-title">GitHub Metrics</h2>
+      <img
+        class="metrics-image"
+        src="https://raw.githubusercontent.com/HukuKaich0u/HukuKaich0u/main/github-metrics.svg"
+        alt="GitHub Metrics"
+        loading="lazy"
+      />
     </section>
   </section>
 </BaseLayout>

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -69,7 +69,7 @@ import ProfileCard from "../../components/ProfileCard.astro";
     </section>
 
     <section class="card">
-      <h2 class="main-title">Quick Access</h2>
+      <h2 class="main-title">Links</h2>
       <ul>
         <li>
           <a href="https://github.com/HukuKaich0u" target="_blank" rel="noreferrer" class="external-link">GitHub</a>
@@ -81,6 +81,16 @@ import ProfileCard from "../../components/ProfileCard.astro";
           <a href="https://www.linkedin.com/in/koki-aoyagi-b3b945349/" target="_blank" rel="noreferrer" class="external-link">LinkedIn</a>
         </li>
       </ul>
+    </section>
+
+    <section class="card stack-md">
+      <h2 class="main-title">GitHub Metrics</h2>
+      <img
+        class="metrics-image"
+        src="https://raw.githubusercontent.com/HukuKaich0u/HukuKaich0u/main/github-metrics.svg"
+        alt="GitHub Metrics"
+        loading="lazy"
+      />
     </section>
   </section>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -386,6 +386,13 @@ a:hover {
   margin: 0;
 }
 
+.metrics-image {
+  display: block;
+  width: min(100%, 520px);
+  height: auto;
+  margin: 0 auto;
+}
+
 .callout {
   border: 1px solid var(--line);
   padding: 0.75rem 0.9rem;


### PR DESCRIPTION
## Summary
- add GitHub Metrics section to both JA/EN home pages
- center and size the metrics SVG for better layout
- rename the social section heading from Quick Access to Links

## Validation
- bun run build
