### PR TITLE
feat: add profile X mention coffee CTA

### DIFF
--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -1,4 +1,5 @@
 ---
+import { Icon } from "astro-icon/components";
 import { Image } from "astro:assets";
 import type { ImageMetadata } from "astro";
 
@@ -9,9 +10,11 @@ interface Props {
   nicknameLabel?: string;
   image?: ImageMetadata;
   imageAlt?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
 }
 
-const { name, bio, nickname, nicknameLabel, image, imageAlt = name } = Astro.props;
+const { name, bio, nickname, nicknameLabel, image, imageAlt = name, ctaLabel, ctaHref } = Astro.props;
 ---
 
 <section class="card">
@@ -29,7 +32,22 @@ const { name, bio, nickname, nicknameLabel, image, imageAlt = name } = Astro.pro
       />
     )}
     <div class="profile-copy">
-      <h1>{name}</h1>
+      <div class="profile-headline">
+        <h1>{name}</h1>
+        {ctaLabel && ctaHref && (
+          <a
+            href={ctaHref}
+            target="_blank"
+            rel="noreferrer"
+            class="profile-cta"
+            aria-label={ctaLabel}
+            title={ctaLabel}
+          >
+            <Icon name="lucide:coffee" />
+            <span class="profile-cta-badge" aria-hidden="true">@</span>
+          </a>
+        )}
+      </div>
       {nickname && (
         <p class="profile-nickname">
           {nicknameLabel ? <span class="profile-nickname-label">{nicknameLabel}: </span> : null}

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -2,6 +2,9 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ProfileCard from "../../components/ProfileCard.astro";
 import profileImage from "../../assets/profile.jpeg";
+
+const xMentionIntentUrl =
+  "https://twitter.com/intent/tweet?text=%40HukuKaich0u%20Let%27s%20have%20a%20coffee%20chat%21";
 ---
 
 <BaseLayout
@@ -20,6 +23,8 @@ import profileImage from "../../assets/profile.jpeg";
       bio="Second-year university student, Software Engineer."
       image={profileImage}
       imageAlt="Koki Aoyagi"
+      ctaLabel="Mention on X"
+      ctaHref={xMentionIntentUrl}
     />
 
     <section class="card stack-md">

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -2,6 +2,9 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import ProfileCard from "../../components/ProfileCard.astro";
 import profileImage from "../../assets/profile.jpeg";
+
+const xMentionIntentUrl =
+  "https://twitter.com/intent/tweet?text=%40HukuKaich0u%20Let%27s%20have%20a%20coffee%20chat%21";
 ---
 
 <BaseLayout
@@ -20,6 +23,8 @@ import profileImage from "../../assets/profile.jpeg";
       bio="大学2年生、ソフトウェアエンジニア"
       image={profileImage}
       imageAlt="青柳幸樹"
+      ctaLabel="Xで誘う"
+      ctaHref={xMentionIntentUrl}
     />
 
     <section class="card stack-md">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -288,8 +288,72 @@ a:hover {
   margin: 0 0 0.4rem;
 }
 
+.profile-headline {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.4rem;
+}
+
+.profile-headline h1 {
+  margin: 0;
+}
+
 .profile-copy {
   min-width: 0;
+}
+
+.profile-cta {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid #c89457;
+  border-radius: 999px;
+  background: #d7a167;
+  color: #fffdf9;
+  text-decoration: none;
+  line-height: 1.2;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.profile-cta svg {
+  width: 1.85rem;
+  height: 1.85rem;
+  transform: translateX(0.12rem);
+}
+
+.profile-cta-badge {
+  position: absolute;
+  right: -0.1rem;
+  bottom: -0.16rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  background: #8b5a2b;
+  color: #ffffff;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1rem;
+  padding-bottom: 0.08rem;
+  box-shadow: 0 0 0 2px var(--bg);
+}
+
+.profile-cta:hover {
+  background: #8b5a2b;
+  border-color: #74461f;
+  color: #ffffff;
+  transform: translateY(-1px);
 }
 
 .profile-nickname {
@@ -490,6 +554,10 @@ a:hover {
   .profile-copy {
     width: 100%;
     text-align: center;
+  }
+
+  .profile-headline {
+    justify-content: center;
   }
 
   .stack-lg > * + * {


### PR DESCRIPTION
## Summary
- add an X mention intent link for the profile CTA
- move the CTA into the profile header and render it as a coffee icon button
- tune the CTA styling, badge placement, and hover colors

## Testing
- not run